### PR TITLE
modbus: close socket on peer-initiated disconnect (fix fd leak)

### DIFF
--- a/protocol/modbus/conn.go
+++ b/protocol/modbus/conn.go
@@ -132,21 +132,26 @@ func (c *TCPConn) Disconnect(ctx context.Context) error {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
-	if !c.connected {
-		return nil
-	}
-
 	c.logger.Info(ctx, "Disconnecting from Modbus TCP server")
 
 	c.connected = false
 
-	close(c.done)
-
-	// Give goroutines a moment to notice the done channel.
-	time.Sleep(10 * time.Millisecond)
-
+	// Tear down exactly once, gated on closeOnce rather than the connected
+	// flag. The read/write loops call setDisconnected the instant the peer
+	// closes the socket (a clean FIN surfaces as io.EOF in readLoop), which
+	// clears c.connected. A `if !c.connected { return }` guard here would then
+	// make the subsequent Disconnect (fired by the transport's Reset) a no-op
+	// and never close the socket, leaking the fd: it sits in CLOSE_WAIT and is
+	// orphaned when a new connection replaces it. Because Connect re-arms
+	// closeOnce (and c.done), each connection is still torn down at most once,
+	// so close(c.done) cannot panic on a double close.
 	var err error
 	c.closeOnce.Do(func() {
+		close(c.done)
+
+		// Give goroutines a moment to notice the done channel.
+		time.Sleep(10 * time.Millisecond)
+
 		c.transactionPool.transactionsMu.Lock()
 		c.transactionPool.unsafeReset()
 		c.transactionPool.transactionsMu.Unlock()

--- a/protocol/modbus/conn_leak_test.go
+++ b/protocol/modbus/conn_leak_test.go
@@ -1,0 +1,89 @@
+package modbus
+
+import (
+	"context"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// countingConn wraps a net.Conn and records how many times Close is called, so
+// a test can assert the underlying socket is actually released.
+type countingConn struct {
+	net.Conn
+	closes atomic.Int32
+}
+
+func (c *countingConn) Close() error {
+	c.closes.Add(1)
+	return c.Conn.Close()
+}
+
+// TestDisconnectClosesSocketAfterPeerClose is a regression test for a file
+// descriptor leak. When the peer closes the connection (a clean FIN surfaces
+// as io.EOF in readLoop), setDisconnected clears c.connected. A Disconnect
+// guarded by `if !c.connected { return nil }` then early-returns and never
+// calls conn.Close(), so the socket is leaked (it lingers in CLOSE_WAIT and is
+// orphaned once the reconnecting transport dials a replacement). This bit an
+// ABB Modbus PLC that closes its connections routinely, accumulating thousands
+// of dead sockets over a few days.
+//
+// The socket must be closed exactly once regardless of who observed the drop
+// first.
+func TestDisconnectClosesSocketAfterPeerClose(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+	wrapped := &countingConn{Conn: clientConn}
+
+	c := NewTCPConn("test", WithConn(wrapped))
+	if err := c.Connect(context.Background()); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+
+	// Simulate a peer-initiated close: the far end sends FIN. readLoop's
+	// io.ReadFull then returns io.EOF and calls setDisconnected, which clears
+	// c.connected before the transport gets a chance to tear the socket down.
+	_ = serverConn.Close()
+
+	// Wait for readLoop to observe the peer close.
+	deadline := time.Now().Add(2 * time.Second)
+	for c.IsConnected() && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if c.IsConnected() {
+		t.Fatal("readLoop did not observe the peer close (connected still true)")
+	}
+
+	// The transport's Closer tears the connection down. Before the fix this
+	// early-returned on !connected and left the socket open.
+	if err := (&TCPCloser{}).Close(c); err != nil {
+		// Close may surface the already-closed pipe error; not a failure.
+		t.Logf("close returned: %v", err)
+	}
+
+	if got := wrapped.closes.Load(); got != 1 {
+		t.Fatalf("underlying socket Close called %d time(s), want 1 "+
+			"(fd leak: Disconnect skipped conn.Close after peer close)", got)
+	}
+}
+
+// TestDisconnectIdempotent guards the other half of the fix: gating teardown on
+// closeOnce (instead of the connected flag) must not let close(c.done) panic on
+// a second Disconnect.
+func TestDisconnectIdempotent(t *testing.T) {
+	_, clientConn := net.Pipe()
+	wrapped := &countingConn{Conn: clientConn}
+
+	c := NewTCPConn("test", WithConn(wrapped))
+	if err := c.Connect(context.Background()); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+
+	closer := &TCPCloser{}
+	_ = closer.Close(c)
+	_ = closer.Close(c) // must not panic (double close of c.done)
+
+	if got := wrapped.closes.Load(); got != 1 {
+		t.Fatalf("underlying socket Close called %d time(s), want 1", got)
+	}
+}


### PR DESCRIPTION
## Problem

`modbus.TCPConn.Disconnect` leaks the underlying socket when the **peer** initiates the close.

`Disconnect` began with:

```go
if !c.connected {
    return nil
}
```

The background `readLoop`/`writeLoop` call `setDisconnected` — which clears `c.connected` — the instant the peer closes the connection (a clean FIN surfaces as `io.EOF` in `readLoop`). The reconnecting transport then observes the failure on the next operation and calls `Reset` → `TCPCloser.Close` → `Disconnect`. But by then `c.connected` is already `false`, so `Disconnect` hits the guard and returns **before ever calling `c.conn.Close()`**. The socket is orphaned: it lingers in `CLOSE_WAIT` and is never released once a new connection replaces it.

Connections dropped by our **own** operation timeout are unaffected (there `c.connected` is still `true` when `Disconnect` runs), which is why this is easy to miss — it only bites against devices that close the connection themselves.

We hit this with an ABB Modbus PLC that closes its TCP connections routinely (roughly once a minute). Each flap leaked one fd; a long-running client accumulated **3953 socket fds for 9 live connections** after ~3 days — an unbounded leak toward fd exhaustion.

## Fix

Gate the teardown on `closeOnce` instead of the `connected` flag, so the socket is closed exactly once regardless of who observed the drop first. `Connect` already re-arms `closeOnce` (and `c.done`) per connection, so `close(c.done)` cannot double-close.

## Tests

`conn_leak_test.go`:

- `TestDisconnectClosesSocketAfterPeerClose` — injects a `Close`-counting `net.Conn`, simulates a peer close (which clears `connected` via `readLoop`), and asserts the socket is still closed exactly once. Fails on the old code, passes with the fix.
- `TestDisconnectIdempotent` — a double `Disconnect` must not panic on `close(c.done)`.

Full package suite and `-race` pass.

Also verified end-to-end against real hardware: a poller driven through a proxy that FINs every 800ms leaked one fd per flap on the old build and stayed flat on the patched build (20 flaps → +20 fds vs +1).
